### PR TITLE
Darken background color to match Gruvbox vim

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 const foregroundColor = '#ebdbb2'
-const backgroundColor = '#282828'
+const backgroundColor = '#262626'
 const black = '#928374'
 const red = '#fb4934'
 const green = '#b8bb26'


### PR DESCRIPTION
Vim’s Gruvbox background color (at least, on my machine) is #262626, not #282828. This change corrects the _very_ slight difference.
